### PR TITLE
Fixes to work with rspec-expectations 3.0+

### DIFF
--- a/spec/lib/te3270/screen_factory_spec.rb
+++ b/spec/lib/te3270/screen_factory_spec.rb
@@ -43,6 +43,6 @@ describe TE3270::ScreenFactory do
     emulator = double('platform')
     world.instance_variable_set('@emulator', emulator)
     world.on(NoTE)
-    world.super_called.should be_true
+    world.super_called.should be true
   end
 end

--- a/spec/lib/te3270_spec.rb
+++ b/spec/lib/te3270_spec.rb
@@ -72,7 +72,7 @@ describe TE3270 do
     end
 
     it 'should call initialize_screen if it exists' do
-      screen_object.initialize_screen.should be_true
+      screen_object.initialize_screen.should be true
     end
 
     it 'should create an emulator and connect to terminal' do


### PR DESCRIPTION
When rspec 3 released be_true was removed.