### PR TITLE
Support for x3270 display models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .idea/
+*.swp

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -12,7 +12,7 @@ module TE3270
       attr_writer :executable_command, :host, :max_wait_time, :trace , :port, :model
 
       def initialize
-        @models = {2 => 24*80, 3 => 32*80, 4 => 43*80}
+        @models = {2 => 24*80, 3 => 32*80, 4 => 43*80, 5 => 27*132}
       end
 
       #

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -41,6 +41,7 @@ module TE3270
         yield self if block_given?
         raise 'The executable command must be set in a block when calling connect with the X3270 emulator.' if @executable_command.nil?
         raise 'The host must be set in a block when calling connect with the X3270 emulator.' if @host.nil?
+        raise 'The model should be one of 1, 2, 3, 4 or 5.' if not @models.key?(@model)
 
         start_x3270_system
       end

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -9,8 +9,8 @@ module TE3270
     #
     class X3270
 
-      attr_writer :executable_command, :host, :max_wait_time, :trace , :port
-
+      attr_writer :executable_command, :host, :max_wait_time, :trace , :port, :model
+      
       #
       # Creates a method to connect to x3270. This method expects a block in which certain
       # platform specific values can be set.  Extra can take the following parameters.
@@ -18,6 +18,7 @@ module TE3270
       # * executable_command - this value is required and should be the name of the ws3270 executable
       # * host - this is required and is the (DNS) name of the host to connect to
       # * max_wait_time - max time to wait in wait_for_string (defaults to 10 if not specified)
+      # * model - the model of 3270 display to be emulated (2, 3, 4, 5), defaults to 2
       #
       # @example Example x3270 object constructor with a block
       #   screen_object = MyScreenObject.new(:x3270)
@@ -32,6 +33,7 @@ module TE3270
         @max_wait_time = 10
         @trace = false
         @port = 23
+        @model = 2 
         yield self if block_given?
         raise 'The executable command must be set in a block when calling connect with the X3270 emulator.' if @executable_command.nil?
         raise 'The host must be set in a block when calling connect with the X3270 emulator.' if @host.nil?
@@ -145,7 +147,11 @@ module TE3270
       # @return [String]
       #
       def text
-        get_string(1,1,24*80)
+        length = 24*80
+        if @model == 3 then
+           length = 32*80
+        end
+        get_string(1,1,length)
       end
 
       private
@@ -174,7 +180,7 @@ module TE3270
       def start_x3270_system
         begin
           args = [
-              "-model", "2",
+              "-model", "#{@model}",
               "", "-port"
           ]
           cmd = "#{@executable_command} #{args.join " "} #{@port} #{@host}"

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -12,7 +12,7 @@ module TE3270
       attr_writer :executable_command, :host, :max_wait_time, :trace , :port, :model
 
       def initialize
-        @models = {2 => 24*80, 3 => 32*80}
+        @models = {2 => 24*80, 3 => 32*80, 4 => 43*80}
       end
 
       #

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -41,7 +41,7 @@ module TE3270
         yield self if block_given?
         raise 'The executable command must be set in a block when calling connect with the X3270 emulator.' if @executable_command.nil?
         raise 'The host must be set in a block when calling connect with the X3270 emulator.' if @host.nil?
-        raise 'The model should be one of 1, 2, 3, 4 or 5.' if not @models.key?(@model)
+        raise 'The model should be one of 2, 3, 4 or 5.' if not @models.key?(@model)
 
         start_x3270_system
       end

--- a/lib/te3270/emulators/x3270.rb
+++ b/lib/te3270/emulators/x3270.rb
@@ -10,7 +10,11 @@ module TE3270
     class X3270
 
       attr_writer :executable_command, :host, :max_wait_time, :trace , :port, :model
-      
+
+      def initialize
+        @models = {2 => 24*80, 3 => 32*80}
+      end
+
       #
       # Creates a method to connect to x3270. This method expects a block in which certain
       # platform specific values can be set.  Extra can take the following parameters.
@@ -147,10 +151,7 @@ module TE3270
       # @return [String]
       #
       def text
-        length = 24*80
-        if @model == 3 then
-           length = 32*80
-        end
+        length = @models[@model]
         get_string(1,1,length)
       end
 

--- a/spec/lib/te3270/emulators/x3270_spec.rb
+++ b/spec/lib/te3270/emulators/x3270_spec.rb
@@ -216,7 +216,7 @@ describe TE3270::Emulators::X3270 do
     it 'should display an error when an unsupported display model is set' do
       expect { x3270.connect do |emulator|
         emulator.model = -1
-      end }.to raise_error('The model should be one of 1, 2, 3, 4 or 5.')
+      end }.to raise_error('The model should be one of 2, 3, 4 or 5.')
     end
 
 

--- a/spec/lib/te3270/emulators/x3270_spec.rb
+++ b/spec/lib/te3270/emulators/x3270_spec.rb
@@ -204,5 +204,14 @@ describe TE3270::Emulators::X3270 do
       expect(x3270.text).to eql 'string'
     end
 
+    it 'should get all text from model 5 screen' do
+      expect(@x3270_io).to receive(:print).with("ascii(0,0,3564)\n")
+      expect(@x3270_io).to receive(:gets).and_return('data: string','goo','ok')
+      x3270.connect do |emulator|
+        emulator.model = 5
+      end
+      expect(x3270.text).to eql 'string'
+    end
+
   end
 end

--- a/spec/lib/te3270/emulators/x3270_spec.rb
+++ b/spec/lib/te3270/emulators/x3270_spec.rb
@@ -195,5 +195,14 @@ describe TE3270::Emulators::X3270 do
       expect(x3270.text).to eql 'string'
     end
 
+    it 'should get all text from model 4 screen' do
+      expect(@x3270_io).to receive(:print).with("ascii(0,0,3440)\n")
+      expect(@x3270_io).to receive(:gets).and_return('data: string','goo','ok')
+      x3270.connect do |emulator|
+        emulator.model = 4
+      end
+      expect(x3270.text).to eql 'string'
+    end
+
   end
 end

--- a/spec/lib/te3270/emulators/x3270_spec.rb
+++ b/spec/lib/te3270/emulators/x3270_spec.rb
@@ -213,5 +213,12 @@ describe TE3270::Emulators::X3270 do
       expect(x3270.text).to eql 'string'
     end
 
+    it 'should display an error when an unsupported display model is set' do
+      expect { x3270.connect do |emulator|
+        emulator.model = -1
+      end }.to raise_error('The model should be one of 1, 2, 3, 4 or 5.')
+    end
+
+
   end
 end

--- a/spec/lib/te3270/emulators/x3270_spec.rb
+++ b/spec/lib/te3270/emulators/x3270_spec.rb
@@ -179,11 +179,21 @@ describe TE3270::Emulators::X3270 do
       x3270.screenshot("image.txt")
     end
 
-    it 'should get all text from screen' do
+    it 'should get all text from model 2 screen' do
       expect(@x3270_io).to receive(:print).with("ascii(0,0,1920)\n")
       expect(@x3270_io).to receive(:gets).and_return('data: string','goo','ok')
       x3270.connect
       expect(x3270.text).to eql 'string'
     end
+
+    it 'should get all text from model 3 screen' do
+      expect(@x3270_io).to receive(:print).with("ascii(0,0,2560)\n")
+      expect(@x3270_io).to receive(:gets).and_return('data: string','goo','ok')
+      x3270.connect do |emulator|
+        emulator.model = 3
+      end
+      expect(x3270.text).to eql 'string'
+    end
+
   end
 end


### PR DESCRIPTION
This adds support for the different display models of the x3270 terminal emulator.

The x3270 emulator supports different display models defining the size of the screen as set by the manual pages:
```
 -model name
              The model of 3270 display to be emulated.  The model name is in two parts, either of which may be omitted:

              The first part is the base model, which is either 3278 or 3279.  3278 specifies a monochrome (green on black) 3270 display; 3279 specifies a color 3270 display.

              The second part is the model number, which specifies the number of rows and columns.  Model 4 is the default.

               Model Number   Columns   Rows
               ---------------------------------
                    2           80       24
                    3           80       32
                    4           80       43
                    5           132      27
```

The current implementation only supports model 2, as `X3270.text` always returns a length of 24*80.

This pull request extends the API of `X3270` with a `model` attribute accepting the values 2, 3, 4 or 5. Buy default `model` is set to 2 to keep backwards compatibility.
Based on the model `X3270.text` fetches the correct screen size.

The RSpec tests have been extended to cover the different display models and the case of passing an unsupported model.

This has been tested against a mainframe using display model 3.


