### PR TITLE
support Rocket BlueZone emulator

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
   * Add troubleshooting info to README
 * Fixes
   * No longer limit bundler version in dev dependency
+  * Fix test that only runs on windows
 
 === Version 0.8.1 / 2017-03-06
 * Fixes

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+=== Upcoming
+* Enhancements
+  * Added support for BlueZone driver (Thanks Jonathan Knapp)
+  * Add troubleshooting info to README
+* Fixes
+  * No longer limit bundler version in dev dependency
+
 === Version 0.8.1 / 2017-03-06
 * Fixes
   * Fixed get_string method for Virtel (Thanks David West)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # TE3270
 
-This gem can be used to drive a 3270 terminal emulator.  You have to have a supported emulator installed on the
-machines on which you use the gem.  Currently the supported emulators are
+This gem can be used to drive a 3270 terminal emulator. You have to have a supported emulator installed on the
+machines on which you use the gem. Currently the supported emulators are
 [EXTRA! X-treme](http://www.attachmate.com/Products/Terminal+Emulation/Extra/xtreme/extra-x-treme.htm) by
-Attachmate, [Quick3270](http://www.dn-computing.com/Quick3270.htm) by DN-Computing, [Virtel Web Access](http://www.virtelweb.com/solutions/3270-terminal-emulation.html),
+Attachmate, [Quick3270](http://www.dn-computing.com/Quick3270.htm) by DN-Computing,
+[Rocket BlueZone](https://www.rocketsoftware.com/products/rocket-bluezonepassport-terminal-emulator/rocket-bluezone-terminal-emulation),
+[Virtel Web Access](http://www.virtelweb.com/solutions/3270-terminal-emulation.html),
 and [X3270](http://x3270.bgp.nu/).
-The first three are commercial products and need to be purchased.
+The first four are commercial products and need to be purchased.
 X3270 is open source. Support for other
 emulators will be added as time permits.
 
@@ -29,7 +31,7 @@ Or install it yourself as:
 
 ## Usage
 
-You can create classes that are similar to page-object classes.  In these classes you can define
+You can create classes that are similar to page-object classes. In these classes you can define
 the various fields that you wish to interact with on the screen.
 
     class MainframeScreen
@@ -90,9 +92,9 @@ or you can use the version of `on` that takes a block like this:
       screen.password = 'the_password'
     end
 
-There is also a way to pass in a `Hash` and have it populate an entire screen.  Just simply
+There is also a way to pass in a `Hash` and have it populate an entire screen. Just simply
 ensure the key for an entry in the `Hash` matches the name you gave a text field and it will
-find and set the value.  This allows the gem to easily work with the DataMagic gem.
+find and set the value. This allows the gem to easily work with the DataMagic gem.
 
     # given this Hash
     my_data = { userid: 'the_id', password: 'the_password' }
@@ -100,6 +102,19 @@ find and set the value.  This allows the gem to easily work with the DataMagic g
     # you can simply call this method
     on(MainframeScreen).populate_screen_with my_data
 
+## Troubleshooting
+
+If you plan to use the BlueZone emulator support, make sure the version of BlueZone
+that you install matches the architecture of the Ruby version you are using.
+
+_ex: x86 for both or 64 bit for both_
+
+Also, if you intend to take screenshots with BlueZone, Extra, or Quick emulators
+you will need to use the x86 version of Ruby as the 64 bit version of
+[win32screenshot](https://rubygems.org/gems/win32screenshot/) depends on
+[rautomation](https://rubygems.org/gems/rautomation/) which
+[does not support 64 bit installs](https://github.com/jarmo/RAutomation/issues/68)
+at this time.
 
 ## Contributing
 

--- a/lib/te3270/emulator_factory.rb
+++ b/lib/te3270/emulator_factory.rb
@@ -1,3 +1,4 @@
+require 'te3270/emulators/bluezone'
 require 'te3270/emulators/extra'
 require 'te3270/emulators/quick3270'
 require 'te3270/emulators/x3270'
@@ -11,6 +12,7 @@ module TE3270
   module EmulatorFactory
 
     EMULATORS = {
+        bluezone: TE3270::Emulators::BlueZone,
         extra: TE3270::Emulators::Extra,
         quick3270: TE3270::Emulators::Quick3270,
         x3270: TE3270::Emulators::X3270,

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -35,7 +35,7 @@ module TE3270
         @timeout = 10
         @visible = true
         @window_state = :normal
-        @write_errors_to_ignore = [6]
+        @write_errors_to_ignore = [5, 6]
         @write_method = :full_string
 
         if jruby?
@@ -67,7 +67,7 @@ module TE3270
       # * visible - determines if the emulator is visible or not. If not set it will default to +true+.
       # * window_state - determines the state of the session window.  Valid values are +:minimized+,
       #   +:normal+, and +:maximized+.  If not set it will default to +:normal+.
-      # * write_errors_to_ignore - array of error codes to ignore during "char" write method. Defaults to +[6]+.
+      # * write_errors_to_ignore - array of error codes to ignore during "char" write method. Defaults to +[5, 6]+.
       # * write_method - write strings to the terminal all at once or one character at a time  Valid values are +:full_string+,
       #   and +:char+.  Default is +:full_string+.
       #

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -114,16 +114,18 @@ module TE3270
       #
       # Puts string at the coordinates specified.
       #
-      # @param [String] str the string to set
+      # @param [String|Fixnum] input the value to set; value is cast to string
       # @param [Fixnum] row the x coordinate of the location on the screen.
       # @param [Fixnum] column the y coordinate of the location on the screen.
       #
-      def put_string(str, row, column)
+      def put_string(input, row, column)
+        input_as_string = input.to_s
+
         if @write_method == :full_string
-          system.WriteScreen(str, row, column)
+          system.WriteScreen(input_as_string, row, column)
           system.WaitReady(@timeout, @max_wait_time)
         elsif @write_method == :char
-          str.chars.each_with_index do |char, index|
+          input_as_string.chars.each_with_index do |char, index|
             position = ((row - 1) * @max_column_length) + column + index
             position_row = (position / @max_column_length.to_f).ceil
             position_col = position % @max_column_length

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -1,0 +1,253 @@
+module TE3270
+  module Emulators
+    class BlueZoneError < StandardError; end
+    class InvalidVisibleStateError < BlueZoneError; end
+    class InvalidWindowStateError < BlueZoneError; end
+    class SessionFileMissingError < BlueZoneError; end
+    class Win32OleRuntimeError < BlueZoneError; end
+
+    #
+    # This class has the code necessary to communicate with the terminal emulator called Rocket BlueZone.
+    # You can use this emulator by providing the +:bluezone+ parameter to the constructor of your screen
+    # object or by passing the same value to the +emulator_for+ method on the +TE3270+ module.
+    #
+    class BlueZone
+      attr_writer :connect_retry_timeout,
+                  :max_column_length,
+                  :max_wait_time,
+                  :session_id,
+                  :session_file
+
+      #
+      # Initialize the emulator with defaults. This also loads libraries used
+      # to take screenshots on supported platforms.
+      #
+      def initialize
+        @connect_retry_timeout = 30
+        @max_column_length = 80
+        @max_wait_time = 1000
+        @session_file = nil
+        @session_id = 1
+        @visible = true
+        @window_state = :normal
+
+        if jruby?
+          require 'jruby-win32ole'
+          require 'java'
+          include_class 'java.awt.Dimension'
+          include_class 'java.awt.Rectangle'
+          include_class 'java.awt.Robot'
+          include_class 'java.awt.Toolkit'
+          include_class 'java.awt.event.InputEvent'
+          include_class 'java.awt.image.BufferedImage'
+          include_class 'javax.imageio.ImageIO'
+        else
+          require 'win32ole'
+          require 'win32/screenshot'
+        end
+      end
+
+      #
+      # Creates a method to connect to BlueZone. This method expects a block in which certain
+      # platform specific values can be set. BlueZone can take the following parameters.
+      #
+      # * connect_retry_timeout - number of seconds to retry connecting to a session. Defaults to +30+.
+      # * max_column_length - number of columns in a terminal row. Defaults to +80+.
+      # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host
+      # * session_file - this value is required and should be the filename of the session.
+      # * session_id - numeric identifer for type of session to connect to. From BlueZone's docs: +1 for S1: 2 for S2; 3 for S3; etc.+ Defaults to +1+.
+      # * visible - determines if the emulator is visible or not. If not set it will default to +true+.
+      # * window_state - determines the state of the session window.  Valid values are +:minimized+,
+      #   +:normal+, and +:maximized+.  If not set it will default to +:normal+.
+      #
+      # @example Example calling screen object constructor with a block
+      #   screen_object = MyScreenObject.new(:bluezone)
+      #   screen_object.connect do |emulator|
+      #     emulator.session_file = 'path_to_session_file'
+      #     emulator.visible = true
+      #     emulator.window_state = :maximized
+      #   end
+      #
+      def connect
+        start_bluezone_system
+        yield self if block_given?
+        raise SessionFileMissingError if @session_file.nil?
+
+        result = system.OpenSession(SESSION_TYPE[:Mainframe], @session_id, @session_file, 10, 1)
+        raise BlueZoneError, "Error opening session: #{result}; #{@session_file}" if result != 0
+
+        result = system.Connect('!', @connect_retry_timeout)
+        raise BlueZoneError, "Error connecting to session: #{result}" if result != 0
+
+        # Once session is started, set pre-configured window_state and visibility.
+        self.window_state = @window_state
+        self.visible = @visible
+      end
+
+      #
+      # Disconnects the BlueZone connection
+      #
+      def disconnect
+        system.CloseSession(SESSION_TYPE[:Mainframe], @session_id)
+      end
+
+      #
+      # Extracts text of specified length from a start point.
+      #
+      # @param [Fixnum] row the x coordinate of location on the screen.
+      # @param [Fixnum] column the y coordinate of location on the screen.
+      # @param [Fixnum] length the length of string to extract
+      # @return [String]
+      #
+      def get_string(row, column, length)
+        system.PSGetText(length, ((row - 1) * @max_column_length) + column)
+      end
+
+      #
+      # Puts string at the coordinates specified.
+      #
+      # @param [String] str the string to set
+      # @param [Fixnum] row the x coordinate of the location on the screen.
+      # @param [Fixnum] column the y coordinate of the location on the screen.
+      #
+      def put_string(str, row, column)
+        system.WriteScreen(str, row, column)
+        system.WaitReady(10, @max_wait_time)
+      end
+
+      #
+      # Creates a method to take screenshot of the active screen. If you have set the +:visible+
+      # property to false it will be made visible prior to taking the screenshot and then changed
+      # to invisible after.
+      #
+      # @param [String] filename the path and name of the screenshot file to be saved
+      #
+      def screenshot(filename)
+        File.delete(filename) if File.exists?(filename)
+        original_visibility = @visible
+        self.visible = true
+
+        if jruby?
+          toolkit = Toolkit::getDefaultToolkit()
+          screen_size = toolkit.getScreenSize()
+          rect = Rectangle.new(screen_size)
+          robot = Robot.new
+          image = robot.createScreenCapture(rect)
+          f = java::io::File.new(filename)
+          ImageIO::write(image, "png", f)
+        else
+          hwnd = system.WindowHandle
+          Win32::Screenshot::Take.of(:window, hwnd: hwnd).write(filename)
+        end
+
+        self.visible = false if original_visibility
+      end
+
+      #
+      # Sends keystrokes to the host, including function keys.
+      #
+      # @param [String] keys keystokes up to 255 in length
+      #
+      def send_keys(keys)
+        system.SendKey(keys)
+        system.WaitReady(10, @max_wait_time)
+      end
+
+      #
+      # Returns the text of the active screen
+      #
+      # @return [String]
+      #
+      def text
+        system.PSText
+      end
+
+      #
+      # Sets the currently connected windows visibility.
+      #
+      # @param [Bool] value
+      #
+      def visible=(value)
+        raise InvalidVisibleStateError, value unless [false, true].include?(value)
+
+        @visible = value
+        window = system.Window
+        window.Visible = value
+      end
+
+      #
+      # Waits for the host to not send data for a specified number of seconds
+      #
+      # @param [Fixnum] seconds the maximum number of seconds to wait
+      #
+      def wait_for_host(seconds)
+        system.Wait(seconds)
+      end
+
+      #
+      # Wait for the string to appear at the specified location
+      #
+      # @param [String] str the string to wait for
+      # @param [Fixnum] row the x coordinate of location
+      # @param [Fixnum] column the y coordinate of location
+      #
+      def wait_for_string(str, row, column)
+        system.WaitForText(str, row, column, 10)
+      end
+
+      #
+      # Waits until the cursor is at the specified location.
+      #
+      # @param [Fixnum] row the x coordinate of the location
+      # @param [Fixnum] column the y coordinate of the location
+      #
+      def wait_until_cursor_at(row, column)
+        system.WaitCursor(10, row, column, 3)
+      end
+
+      #
+      # Sets the currently connected windows state.
+      #
+      # @param [Symbol] state
+      #
+      def window_state=(state)
+        raise InvalidWindowStateError, state unless WINDOW_STATE.keys.include?(state)
+
+        @window_state = state
+        system.WindowState = WINDOW_STATE[state]
+      end
+
+      private
+
+      SESSION_TYPE = {
+        Mainframe: 0,
+        iSeries: 1,
+        VT: 2,
+        UTS: 3,
+        T27: 4,
+        '6530': 6
+      }.freeze
+
+      WINDOW_STATE = {
+        maximized: 2,
+        minimized: 1,
+        normal: 0
+      }.freeze
+
+      attr_reader :system
+
+      def jruby?
+        RUBY_PLATFORM == 'java'
+      end
+
+      def start_bluezone_system
+        begin
+          @system = WIN32OLE.new('BZWhll.WhllObj')
+        rescue Win32OleRuntimeError => exception
+          $stderr.puts exception
+          raise MissingOleRuntimeError, 'Unable to find BZWhll.WhllObj OLE runtime. Did you install the same BlueZone Desktop architecture as your Ruby runtime? ex: x86 vs 64 bit'
+        end
+      end
+    end
+  end
+end

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -55,9 +55,9 @@ module TE3270
       #
       # * connect_retry_timeout - number of seconds to retry connecting to a session. Defaults to +30+.
       # * max_column_length - number of columns in a terminal row. Defaults to +80+.
-      # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host
+      # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host. Defaults to +1000+.
       # * session_file - this value is required and should be the filename of the session.
-      # * session_id - numeric identifer for type of session to connect to. From BlueZone's docs: +1 for S1: 2 for S2; 3 for S3; etc.+ Defaults to +1+.
+      # * session_id - numeric identifier for type of session to connect to. From BlueZone's docs: +1 for S1: 2 for S2; 3 for S3; etc.+ Defaults to +1+.
       # * timeout - numeric number of seconds till system calls timeout. Defaults to +10+.
       # * visible - determines if the emulator is visible or not. If not set it will default to +true+.
       # * window_state - determines the state of the session window.  Valid values are +:minimized+,

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -26,7 +26,7 @@ module TE3270
       def initialize
         @connect_retry_timeout = 30
         @max_column_length = 80
-        @max_wait_time = 1000
+        @max_wait_time = 100
         @session_file = nil
         @session_id = 1
         @timeout = 10
@@ -55,7 +55,7 @@ module TE3270
       #
       # * connect_retry_timeout - number of seconds to retry connecting to a session. Defaults to +30+.
       # * max_column_length - number of columns in a terminal row. Defaults to +80+.
-      # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host. Defaults to +1000+.
+      # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host. Defaults to +100+.
       # * session_file - this value is required and should be the filename of the session.
       # * session_id - numeric identifier for type of session to connect to. From BlueZone's docs: +1 for S1: 2 for S2; 3 for S3; etc.+ Defaults to +1+.
       # * timeout - numeric number of seconds till system calls timeout. Defaults to +10+.

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -81,10 +81,6 @@ module TE3270
 
         result = system.Connect('!', @connect_retry_timeout)
         raise BlueZoneError, "Error connecting to session: #{result}" if result != 0
-
-        # Once session is started, set pre-configured window_state and visibility.
-        self.window_state = @window_state
-        self.visible = @visible
       end
 
       #
@@ -143,7 +139,7 @@ module TE3270
           Win32::Screenshot::Take.of(:window, hwnd: hwnd).write(filename)
         end
 
-        self.visible = false if original_visibility
+        self.visible = false unless original_visibility
       end
 
       #
@@ -246,6 +242,11 @@ module TE3270
       def start_bluezone_system
         begin
           @system = WIN32OLE.new('BZWhll.WhllObj')
+
+          # Default window state.
+          # Once session is "connected" these will be applied unless overwritten.
+          self.window_state = @window_state
+          self.visible = @visible
         rescue Win32OleRuntimeError => exception
           $stderr.puts exception
           raise MissingOleRuntimeError, 'Unable to find BZWhll.WhllObj OLE runtime. Did you install the same BlueZone Desktop architecture as your Ruby runtime? ex: x86 vs 64 bit'

--- a/lib/te3270/emulators/bluezone.rb
+++ b/lib/te3270/emulators/bluezone.rb
@@ -16,7 +16,8 @@ module TE3270
                   :max_column_length,
                   :max_wait_time,
                   :session_id,
-                  :session_file
+                  :session_file,
+                  :timeout
 
       #
       # Initialize the emulator with defaults. This also loads libraries used
@@ -28,6 +29,7 @@ module TE3270
         @max_wait_time = 1000
         @session_file = nil
         @session_id = 1
+        @timeout = 10
         @visible = true
         @window_state = :normal
 
@@ -56,6 +58,7 @@ module TE3270
       # * max_wait_time - number of milliseconds to wait before resuming script execution after sending keys from host
       # * session_file - this value is required and should be the filename of the session.
       # * session_id - numeric identifer for type of session to connect to. From BlueZone's docs: +1 for S1: 2 for S2; 3 for S3; etc.+ Defaults to +1+.
+      # * timeout - numeric number of seconds till system calls timeout. Defaults to +10+.
       # * visible - determines if the emulator is visible or not. If not set it will default to +true+.
       # * window_state - determines the state of the session window.  Valid values are +:minimized+,
       #   +:normal+, and +:maximized+.  If not set it will default to +:normal+.
@@ -73,7 +76,7 @@ module TE3270
         yield self if block_given?
         raise SessionFileMissingError if @session_file.nil?
 
-        result = system.OpenSession(SESSION_TYPE[:Mainframe], @session_id, @session_file, 10, 1)
+        result = system.OpenSession(SESSION_TYPE[:Mainframe], @session_id, @session_file, @timeout, 1)
         raise BlueZoneError, "Error opening session: #{result}; #{@session_file}" if result != 0
 
         result = system.Connect('!', @connect_retry_timeout)
@@ -112,7 +115,7 @@ module TE3270
       #
       def put_string(str, row, column)
         system.WriteScreen(str, row, column)
-        system.WaitReady(10, @max_wait_time)
+        system.WaitReady(@timeout, @max_wait_time)
       end
 
       #
@@ -150,7 +153,7 @@ module TE3270
       #
       def send_keys(keys)
         system.SendKey(keys)
-        system.WaitReady(10, @max_wait_time)
+        system.WaitReady(@timeout, @max_wait_time)
       end
 
       #
@@ -192,7 +195,7 @@ module TE3270
       # @param [Fixnum] column the y coordinate of location
       #
       def wait_for_string(str, row, column)
-        system.WaitForText(str, row, column, 10)
+        system.WaitForText(str, row, column, @timeout)
       end
 
       #
@@ -202,7 +205,7 @@ module TE3270
       # @param [Fixnum] column the y coordinate of the location
       #
       def wait_until_cursor_at(row, column)
-        system.WaitCursor(10, row, column, 3)
+        system.WaitCursor(@timeout, row, column, 3)
       end
 
       #

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -37,6 +37,14 @@ describe TE3270::Emulators::BlueZone do
       end
     end
 
+    it 'should call a block with custom session number to be set' do
+      expect(bluezone_system).to receive(:OpenSession).with(0, 2, 'blah.edp', 10, 1).and_return(0)
+      bluezone.connect do |platform|
+        platform.session_id = 2
+        platform.session_file = 'blah.edp'
+      end
+    end
+
     it 'should raise an error when the session file is not set' do
       bluezone.instance_variable_set(:@session_file, nil)
       expect { bluezone.connect }.to raise_error(TE3270::Emulators::SessionFileMissingError)
@@ -71,9 +79,23 @@ describe TE3270::Emulators::BlueZone do
       bluezone.connect
     end
 
+    it 'should get the connection with custom connection retry timeout for the active session' do
+      expect(bluezone_system).to receive(:Connect).with("!", 0).and_return(0)
+      bluezone.connect_retry_timeout = 0
+      bluezone.connect
+    end
+
     it 'should disconnect from a session' do
       expect(bluezone_system).to receive(:CloseSession).with(0, 1)
       bluezone.connect
+      bluezone.disconnect
+    end
+
+    it 'should disconnect from a custom session id' do
+      expect(bluezone_system).to receive(:CloseSession).with(0, 2)
+      bluezone.connect do |platform|
+        platform.session_id = 2
+      end
       bluezone.disconnect
     end
   end
@@ -99,6 +121,14 @@ describe TE3270::Emulators::BlueZone do
       bluezone.connect
       bluezone.put_string('blah', 1, 2)
     end
+
+    it 'should put the value on the screen with reduced wait delay if overridden' do
+      expect(bluezone_system).to receive(:WriteScreen).with('blah', 1, 2)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
+      bluezone.connect
+      bluezone.max_wait_time = 100
+      bluezone.put_string('blah', 1, 2)
+    end
   end
 
   describe "interacting with the screen" do
@@ -109,9 +139,24 @@ describe TE3270::Emulators::BlueZone do
       bluezone.send_keys(TE3270.Clear)
     end
 
+    it 'should know how to send function keys with reduced wait delay if overridden' do
+      expect(bluezone_system).to receive(:SendKey).with('<Clear>')
+      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
+      bluezone.connect
+      bluezone.max_wait_time = 100
+      bluezone.send_keys(TE3270.Clear)
+    end
+
     it 'should wait for a string to appear' do
       expect(bluezone_system).to receive(:WaitForText).with('The String', 3, 10, 10).and_return(0)
       bluezone.connect
+      bluezone.wait_for_string('The String', 3, 10)
+    end
+
+    it 'should respect custom timeout for a string to appear' do
+      expect(bluezone_system).to receive(:WaitForText).with('The String', 3, 10, 24).and_return(0)
+      bluezone.connect
+      bluezone.timeout = 24
       bluezone.wait_for_string('The String', 3, 10)
     end
 
@@ -124,6 +169,13 @@ describe TE3270::Emulators::BlueZone do
     it 'should wait until the cursor is at a position' do
       expect(bluezone_system).to receive(:WaitCursor).with(10, 5, 8, 3).and_return(0)
       bluezone.connect
+      bluezone.wait_until_cursor_at(5, 8)
+    end
+
+    it 'should respect custom timeout while waiting until the cursor is at a position' do
+      expect(bluezone_system).to receive(:WaitCursor).with(24, 5, 8, 3).and_return(0)
+      bluezone.connect
+      bluezone.timeout = 24
       bluezone.wait_until_cursor_at(5, 8)
     end
 

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+
+describe TE3270::Emulators::BlueZone do
+
+  unless Gem.win_platform?
+    class WIN32OLE
+    end
+  end
+
+  let(:bluezone) do
+    allow_any_instance_of(TE3270::Emulators::BlueZone).to receive(:require) unless Gem.win_platform?
+    TE3270::Emulators::BlueZone.new
+  end
+
+  before(:each) do
+    allow(WIN32OLE).to receive(:new).and_return bluezone_system
+    bluezone.instance_variable_set(:@session_file, 'the_file')
+    allow(File).to receive(:exists).and_return false
+  end
+
+
+  describe "global behaviors" do
+    it 'should start a new terminal' do
+      expect(WIN32OLE).to receive(:new).and_return(bluezone_system)
+      bluezone.connect
+    end
+
+    it 'should open a session' do
+      expect(bluezone_system).to receive(:OpenSession).and_return(0)
+      bluezone.connect
+    end
+
+    it 'should call a block allowing the session file to be set' do
+      expect(bluezone_system).to receive(:OpenSession).with(0, 1, 'blah.edp', 10, 1).and_return(0)
+      bluezone.connect do |platform|
+        platform.session_file = 'blah.edp'
+      end
+    end
+
+    it 'should raise an error when the session file is not set' do
+      bluezone.instance_variable_set(:@session_file, nil)
+      expect { bluezone.connect }.to raise_error(TE3270::Emulators::SessionFileMissingError)
+    end
+
+    it 'should take the visible value from a block' do
+      expect(bluezone_window).to receive(:Visible=).with(false)
+      bluezone.connect do |platform|
+        platform.visible = false
+      end
+    end
+
+    it 'should default to visible when not specified' do
+      expect(bluezone_window).to receive(:Visible=).with(true)
+      bluezone.connect
+    end
+
+    it 'should take the window state value from the block' do
+      expect(bluezone_system).to receive(:WindowState=).with(2)
+      bluezone.connect do |platform|
+        platform.window_state = :maximized
+      end
+    end
+
+    it 'should default to window state normal when not specified' do
+      expect(bluezone_system).to receive(:WindowState=).with(0)
+      bluezone.connect
+    end
+
+    it 'should get the connection for the active session' do
+      expect(bluezone_system).to receive(:Connect).with("!", 30).and_return(0)
+      bluezone.connect
+    end
+
+    it 'should disconnect from a session' do
+      expect(bluezone_system).to receive(:CloseSession).with(0, 1)
+      bluezone.connect
+      bluezone.disconnect
+    end
+  end
+
+  describe "interacting with text fields" do
+    it 'should get the value from the screen' do
+      expect(bluezone_system).to receive(:PSGetText).with(10, 1532).and_return('blah')
+      bluezone.connect
+      expect(bluezone.get_string(20, 12, 10)).to eql 'blah'
+    end
+
+    it 'should get the value from the screen if columns were set to 100' do
+      expect(bluezone_system).to receive(:PSGetText).with(10, 1912).and_return('blah')
+      bluezone.connect do |platform|
+        platform.max_column_length = 100
+      end
+      expect(bluezone.get_string(20, 12, 10)).to eql 'blah'
+    end
+
+    it 'should put the value on the screen' do
+      expect(bluezone_system).to receive(:WriteScreen).with('blah', 1, 2)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 1000)
+      bluezone.connect
+      bluezone.put_string('blah', 1, 2)
+    end
+  end
+
+  describe "interacting with the screen" do
+    it 'should know how to send function keys' do
+      expect(bluezone_system).to receive(:SendKey).with('<Clear>')
+      expect(bluezone_system).to receive(:WaitReady).with(10, 1000)
+      bluezone.connect
+      bluezone.send_keys(TE3270.Clear)
+    end
+
+    it 'should wait for a string to appear' do
+      expect(bluezone_system).to receive(:WaitForText).with('The String', 3, 10, 10).and_return(0)
+      bluezone.connect
+      bluezone.wait_for_string('The String', 3, 10)
+    end
+
+    it 'should wait for the host to be quiet' do
+      expect(bluezone_system).to receive(:Wait).with(4)
+      bluezone.connect
+      bluezone.wait_for_host(4)
+    end
+
+    it 'should wait until the cursor is at a position' do
+      expect(bluezone_system).to receive(:WaitCursor).with(10, 5, 8, 3).and_return(0)
+      bluezone.connect
+      bluezone.wait_until_cursor_at(5, 8)
+    end
+
+    it "should get the screen text" do
+      expect(bluezone_system).to receive(:PSText).and_return('blah')
+      bluezone.connect
+      expect(bluezone.text).to eql 'blah'
+    end
+
+    if Gem.win_platform?
+      it 'should take screenshots' do
+        take = double('Take')
+        expect(bluezone_system).to receive(:WindowHandle).and_return(123)
+        expect(Win32::Screenshot::Take).to receive(:of).with(:window, hwnd: 123).and_return(take)
+        expect(take).to receive(:write).with('image.png')
+        bluezone.connect
+        bluezone.screenshot('image.png')
+      end
+
+      it 'should make the window visible before taking a screenshot' do
+        take = double('Take')
+        expect(bluezone_system).to receive(:WindowHandle).and_return(123)
+        expect(Win32::Screenshot::Take).to receive(:of).with(:window, hwnd: 123).and_return(take)
+        expect(take).to receive(:write).with('image.png')
+        expect(bluezone_window).to receive(:Visible=).once.with(true)
+        expect(bluezone_window).to receive(:Visible=).twice.with(false)
+        bluezone.connect do |emulator|
+          emulator.visible = false
+        end
+        bluezone.screenshot('image.png')
+      end
+
+      it 'should delete the file for the screenshot if it already exists' do
+        expect(File).to receive(:exists?).and_return(true)
+        expect(File).to receive(:delete)
+        take = double('Take')
+        expect(bluezone_system).to receive(:WindowHandle).and_return(123)
+        expect(Win32::Screenshot::Take).to receive(:of).with(:window, hwnd: 123).and_return(take)
+        expect(take).to receive(:write).with('image.png')
+        bluezone.connect
+        bluezone.screenshot('image.png')
+      end
+    end
+  end
+end

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -168,6 +168,13 @@ describe TE3270::Emulators::BlueZone do
         bluezone.max_wait_time = 111
         bluezone.put_string('blah', 1, 2)
       end
+
+      it 'should cast the value to a string before printing to the screen' do
+        expect(bluezone_system).to receive(:WriteScreen).with('1234', 1, 2)
+        expect(bluezone_system).to receive(:WaitReady).with(10, 100).once
+        bluezone.connect
+        bluezone.put_string(1234, 1, 2)
+      end
     end
 
     describe "char write method" do
@@ -218,6 +225,16 @@ describe TE3270::Emulators::BlueZone do
           platform.write_errors_to_ignore = [4, 5, 6]
         end
         bluezone.put_string('blah', 1, 2)
+      end
+
+      it 'should cast the value to a string before printing to the screen' do
+        expect(bluezone_system).to receive(:WriteScreen).with('1', 1, 2).once.and_return(0)
+        expect(bluezone_system).to receive(:WriteScreen).with('2', 1, 3).once.and_return(0)
+        expect(bluezone_system).to receive(:WriteScreen).with('3', 1, 4).once.and_return(0)
+        expect(bluezone_system).to receive(:WriteScreen).with('4', 1, 5).once.and_return(0)
+        expect(bluezone_system).to receive(:WaitReady).with(10, 100).exactly(4).times
+        bluezone.connect
+        bluezone.put_string(1234, 1, 2)
       end
     end
   end

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -200,7 +200,7 @@ describe TE3270::Emulators::BlueZone do
         expect(bluezone_system).to receive(:WindowHandle).and_return(123)
         expect(Win32::Screenshot::Take).to receive(:of).with(:window, hwnd: 123).and_return(take)
         expect(take).to receive(:write).with('image.png')
-        expect(bluezone_window).to receive(:Visible=).once.with(true)
+        expect(bluezone_window).to receive(:Visible=).twice.with(true)
         expect(bluezone_window).to receive(:Visible=).twice.with(false)
         bluezone.connect do |emulator|
           emulator.visible = false

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -117,16 +117,16 @@ describe TE3270::Emulators::BlueZone do
 
     it 'should put the value on the screen' do
       expect(bluezone_system).to receive(:WriteScreen).with('blah', 1, 2)
-      expect(bluezone_system).to receive(:WaitReady).with(10, 1000)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
       bluezone.connect
       bluezone.put_string('blah', 1, 2)
     end
 
     it 'should put the value on the screen with reduced wait delay if overridden' do
       expect(bluezone_system).to receive(:WriteScreen).with('blah', 1, 2)
-      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 111)
       bluezone.connect
-      bluezone.max_wait_time = 100
+      bluezone.max_wait_time = 111
       bluezone.put_string('blah', 1, 2)
     end
   end
@@ -134,16 +134,16 @@ describe TE3270::Emulators::BlueZone do
   describe "interacting with the screen" do
     it 'should know how to send function keys' do
       expect(bluezone_system).to receive(:SendKey).with('<Clear>')
-      expect(bluezone_system).to receive(:WaitReady).with(10, 1000)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
       bluezone.connect
       bluezone.send_keys(TE3270.Clear)
     end
 
     it 'should know how to send function keys with reduced wait delay if overridden' do
       expect(bluezone_system).to receive(:SendKey).with('<Clear>')
-      expect(bluezone_system).to receive(:WaitReady).with(10, 100)
+      expect(bluezone_system).to receive(:WaitReady).with(10, 111)
       bluezone.connect
-      bluezone.max_wait_time = 100
+      bluezone.max_wait_time = 111
       bluezone.send_keys(TE3270.Clear)
     end
 

--- a/spec/lib/te3270/emulators/bluezone_spec.rb
+++ b/spec/lib/te3270/emulators/bluezone_spec.rb
@@ -100,7 +100,6 @@ describe TE3270::Emulators::BlueZone do
     end
 
     it 'should set write_method to :full_string by default' do
-      # bluezone = TE3270::Emulators::BlueZone.new
       expect(bluezone.instance_variable_get(:@write_method)).to eq(:full_string)
     end
 
@@ -119,9 +118,9 @@ describe TE3270::Emulators::BlueZone do
       expect { bluezone.connect }.to raise_error(TE3270::Emulators::InvalidWriteMethodError)
     end
 
-    it 'should set write_errors_to_ignore to [6] by default' do
+    it 'should set write_errors_to_ignore to [5, 6] by default' do
       bluezone = TE3270::Emulators::BlueZone.new
-      expect(bluezone.instance_variable_get(:@write_errors_to_ignore)).to eq([6])
+      expect(bluezone.instance_variable_get(:@write_errors_to_ignore)).to eq([5, 6])
     end
 
     it 'should allow setting write_errors_to_ignore to array of integers' do

--- a/spec/lib/te3270_spec.rb
+++ b/spec/lib/te3270_spec.rb
@@ -84,13 +84,13 @@ describe TE3270 do
     if Gem.win_platform?
       it 'should accept a block when creating an emulator' do
         expect(WIN32OLE).to receive(:new).and_return(extra_system)
-        expect(extra_session).to receive(:Open).with('blah.edp').and_return(extra_session)
+        expect(extra_system.Sessions).to receive(:Open).with('blah.edp').and_return(extra_session)
         TE3270.emulator_for :extra do |emulator|
           emulator.session_file = 'blah.edp'
         end
       end
     end
-    
+
     it 'should allow one to disconnect using the module' do
       expect(platform).to receive(:disconnect)
       TE3270.disconnect(platform)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,20 @@ if Gem.win_platform?
   require 'win32/screenshot'
 end
 
+def bluezone_system
+  @bluezone_system ||= double('system')
+  allow(@bluezone_system).to receive(:Connect).and_return(0)
+  allow(@bluezone_system).to receive(:OpenSession).and_return(0)
+  allow(@bluezone_system).to receive(:Window).and_return(bluezone_window)
+  allow(@bluezone_system).to receive(:WindowState=)
+  @bluezone_system
+end
+
+def bluezone_window
+  @bluezone_window ||= double('window')
+  allow(@bluezone_window).to receive(:Visible=)
+  @bluezone_window
+end
 
 def extra_system
   @extra_system ||= double('system')

--- a/te3270.gemspec
+++ b/te3270.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'watir', '~> 6.0'
   spec.add_dependency 'win32screenshot' if Gem.win_platform?
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This adds support for Rocket's BlueZone terminal emulator. The bulk of the work aligns with how the Extra emulator works in this gem.

While working on the changes, I found that x86 installs of Ruby can take screenshots but 64 bit installs can't. I added some info to the README to help with troubleshooting items like these.

Other changes include:

- removing dev restriction around the `bundler` version to use (since 2+ is out now)
- fixing a test that appeared to be broken when running the suite on windows

---------

Let me know if you'd like to see anything else to confidently get this PR merged.

I created an [example repo](https://github.com/CoffeeAndCode/te3270-and-hercules) while adding support for the new emulator that runs cucumber tests using the te3270 gem against a Hercules terminal running inside Docker.